### PR TITLE
Recolor online status, microphone mute cross out, etc; and Add dark variant theme

### DIFF
--- a/nord-darker.theme.css
+++ b/nord-darker.theme.css
@@ -102,8 +102,8 @@
 	margin-top      : 0;
 }
 
-.da-content > .da-sidebar {
-	border-radius: 0px;
+.da-bg {
+	background-color: var(--nordBlack);
 }
 
 /* Mac style buttons */

--- a/nord-darker.theme.css
+++ b/nord-darker.theme.css
@@ -102,6 +102,10 @@
 	margin-top      : 0;
 }
 
+.da-content > .da-sidebar {
+	border-radius: 0px;
+}
+
 /* Mac style buttons */
 /* ! The clickable area is too small. */
 .da-winButton {

--- a/nord-darker.theme.css
+++ b/nord-darker.theme.css
@@ -213,6 +213,7 @@
 /* ! Better solution needed. The animation does not transit smoothly */
 .da-avatar .da-wrapper[aria-label$="Online"] > svg > svg > rect[width="25"],
 .da-avatar[aria-label$="Online"] > svg > svg > rect[width="25"],
+.da-avatar .da-wrapper[aria-label$="mobile"] > svg > rect[width="10"],
 rect[mask="url(#svg-mask-status-online)"] {
 	fill: var(--nord14);
 }

--- a/nord-darker.theme.css
+++ b/nord-darker.theme.css
@@ -1,0 +1,225 @@
+/**
+ * @name nordDiscord-Darker
+ * @description A dark Discord palette conversion to arcticicestudio's NordTheme. Uses mwittrien's DiscordRecolor CSS as a base with our own additions.
+ * @author izutsumi, IDislikeChair, mwittrien
+ * @version 1.0.1
+ * @website https://github.com/izutsumi/nordDiscord
+ * @source https://raw.githubusercontent.com/izutsumi/nordDiscord/master/nord-darker.theme.css
+ */
+
+/* DiscordRecolor CSS by mwittrien */
+@import url("https://mwittrien.github.io/BetterDiscordAddons/Themes/DiscordRecolor/DiscordRecolor.css");
+/* Nord Highlight.js */
+@import url("https://unpkg.com/nord-highlightjs@0.1.0/dist/nord.css");
+/* RadialStautus */
+/* @import url("https://discordstyles.github.io/RadialStatus/base.css"); */
+
+
+:root {
+	/* Variables from DiscordRecolor. RGBA values only. */
+	--accentcolor : 94,  129, 172;
+	--linkcolor   : 136, 192, 208;
+	--mentioncolor: 136, 192, 208;
+	
+	--textbrightest: 236, 239, 244;
+	--textbrighter : 229, 233, 240;
+	--textbright   : 216, 222, 233;
+	--textdark     : 216, 222, 233;
+	--textdarker   : 130, 148, 182;
+	--textdarkest  : 76,  86,  106;
+
+	--backgroundaccent      : 59, 66, 82;
+	--backgroundprimary     : 46, 52, 64;
+	--backgroundsecondary   : 46, 52, 64;
+	--backgroundsecondaryalt: 46, 52, 64;
+	--backgroundtertiary    : 59, 66, 82;
+	--backgroundfloating    : 37, 41, 50;
+	
+	
+	/* Radial Status variable */
+	--rs-small-spacing  : 1px;            /* spacing between avatar and status */
+	--rs-large-spacing  : 3px;            /* spacing between avatar and status for user popouts & modals/profiles */
+	--rs-width          : 2px;            /* Width/thickness of status border */
+	--rs-avatar-shape   : 50%;            /* 50% for round - 0% for square */
+	--rs-online-color   : var(--nord14);  /* color for online status */
+	--rs-idle-color     : var(--nord13);  /* color for idle status */
+	--rs-dnd-color      : var(--nord11);  /* color for dnd status */
+	--rs-offline-color  : var(--nord3);   /* color for offline status */
+	--rs-streaming-color: var(--nord15);  /* color for streaming status */
+	--rs-invisible-color: var(--nord3);   /* color for invisible status - Note this will only show for your own invisibility */
+	
+	
+	/* Nord color scheme */
+	--nord0    : #2e3440;
+	--nord1    : #3b4252;
+	--nord2    : #434c5e;
+	--nord3    : #4c566a;
+	--nord4    : #d8dee9;
+	--nord5    : #e5e9f0;
+	--nord6    : #eceff4;
+	--nord7    : #8fbcbb;
+	--nord8    : #88c0d0;
+	--nord9    : #81a1c1;
+	--nord10   : #5e81ac;
+	--nord11   : #bf616a;
+	--nord12   : #d08770;
+	--nord13   : #ebcb8b;
+	--nord14   : #a3be8c;
+	--nord15   : #b48ead;
+	--nordBlack: #252932;
+}
+
+/* Change scroll bar color */
+.theme-dark, .theme-light {
+
+	--scrollbar-thin-thumb                : var(--nord1);
+	--scrollbar-thin-track                : transparent;
+	--scrollbar-auto-thumb                : var(--nord1);
+	--scrollbar-auto-track                : transparent;
+	--scrollbar-auto-scrollbar-color-thumb: var(--nord1);
+	--scrollbar-auto-scrollbar-color-track: transparent;
+}
+
+/* Discord logo */
+.da-wordmark path {
+	fill: var(--nord4);
+}
+
+/* Message search bar */
+.da-searchBar {
+	background-color: var(--nord0);
+}
+
+/* Server list */
+.da-tree > .da-scroller {
+	background-color: var(--nordBlack);
+}
+
+/* Title bar */
+.da-titleBar {
+	background-color: var(--nordBlack) !important;
+	padding-top     : 4px;
+	margin-top      : 0;
+}
+
+/* Mac style buttons */
+/* ! The clickable area is too small. */
+.da-winButton {
+	color        : transparent;
+	height       : 10px;
+	width        : 10px;
+	border-radius: 50%;
+	margin-top   : 5px;
+	margin-right : 10px;
+	margin-left  : 10px;
+
+	transition: .2s;
+}
+
+.da-winButtonMinMax[aria-label="Minimize"] {
+	background-color: var(--nord13);
+}
+
+.da-winButtonMinMax[aria-label="Maximize"] {
+	background-color: var(--nord14);
+}
+
+.da-winButtonClose {
+	background-color: var(--nord11);
+	margin-right    : 25px
+}
+
+.da-winButton:hover {
+	color           : transparent;
+	background-color: var(--nord3);
+}
+
+/* Text Highlighting Styling */
+::selection {
+    background-color: rgba(129, 161, 193,.5);
+    color           : var(--nord4);
+}
+
+/* Mention Border */
+.da-mentioned:before {
+    background-color: rgb(var(--mentioncolor));
+}
+
+/* New Messages Divider & Pill */
+.da-isUnread .da-content {
+    color: var(--nord11) !important;
+}
+
+.da-nameWrap .da-textRow {
+    background-color: transparent;
+}
+
+.da-isUnread {
+    border-color: var(--nord11);
+}
+
+.da-unreadPill {
+    background-color: var(--nord11);
+}
+
+.da-unreadPillCapStroke {
+    color: var(--nord11);
+    fill : var(--nord11);
+}
+
+/* Folder Icon and Background Colors  */
+.da-expandedFolderIconWrapper path {
+    fill: rgb(var(--accentcolor));
+}
+
+.da-folderIconWrapper {
+    background-color: var(--nord0) !important;
+}
+
+/* Administrator Crown */
+.da-ownerIcon {
+    color: var(--nord13);
+}
+
+/* Premium Icon */
+.da-premiumIcon {
+	color: var(--nord15);
+}
+
+/* Add Server & Explore Buttons */
+.da-circleIconButton {
+    color: var(--nord4);
+}
+
+.da-circleIconButton.da-selected, .da-selected .da-childWrapper {
+    background-color: var(--nord2);
+}
+
+/* New pin icon */
+.da-iconBadge {
+	background-color: var(--nord11);
+}
+
+/* Microphone and speaker mute */
+.da-strikethrough {
+	color: var(--nord11);
+}
+
+/* Status icons */
+.da-pointerEvents[mask="url(#svg-mask-status-online)"], 
+.da-pointerEvents[mask="url(#svg-mask-status-online-mobile)"] {
+	fill: var(--nord14);
+}
+
+.da-pointerEvents[mask="url(#svg-mask-status-dnd)"] {
+	fill: var(--nord11);
+}
+
+.da-pointerEvents[mask="url(#svg-mask-status-streaming)"] {
+	fill: var(--nord15);
+}
+
+.da-pointerEvents[mask="url(#svg-mask-status-idle)"],
+.da-cursorDefault > rect  {
+	fill: var(--nord13);
+}

--- a/nord-darker.theme.css
+++ b/nord-darker.theme.css
@@ -210,19 +210,55 @@
 }
 
 /* Status icons */
-.da-pointerEvents[mask="url(#svg-mask-status-online)"], 
-.da-pointerEvents[mask="url(#svg-mask-status-online-mobile)"] {
+/* ! Better solution needed. The animation does not transit smoothly */
+.da-avatar .da-wrapper[aria-label$="Online"] > svg > svg > rect[width="25"],
+.da-avatar[aria-label$="Online"] > svg > svg > rect[width="25"],
+rect[mask="url(#svg-mask-status-online)"] {
 	fill: var(--nord14);
 }
 
-.da-pointerEvents[mask="url(#svg-mask-status-dnd)"] {
+.da-status[style="background-color: rgb(67, 181, 129);"] {
+	background-color: var(--nord14) !important;
+}
+
+
+.da-avatar .da-wrapper[aria-label$="Do Not Disturb"] > svg > svg > rect[width="25"],
+.da-avatar[aria-label$="Do Not Disturb"] > svg > svg > rect[width="25"],
+rect[mask="url(#svg-mask-status-dnd)"] {
 	fill: var(--nord11);
 }
 
-.da-pointerEvents[mask="url(#svg-mask-status-streaming)"] {
+.da-status[style="background-color: rgb(240, 71, 71);"] {
+	background-color: var(--nord11) !important;
+}
+
+.da-avatar .da-wrapper[aria-label$="Streaming"] > svg > svg > rect[width="25"],
+.da-avatar[aria-label$="Streaming"] > svg > svg > rect[width="25"],
+rect[mask="url(#svg-mask-status-streaming)"] {
 	fill: var(--nord15);
 }
 
-.da-pointerEvents[mask="url(#svg-mask-status-idle)"] {
+.da-status[style="background-color: rgb(89, 54, 149);"] {
+	background-color: var(--nord15) !important;
+}
+
+.da-avatar .da-wrapper[aria-label$="Idle"] > svg > svg > rect[width="25"],
+.da-avatar[aria-label$="Idle"] > svg > svg > rect[width="25"],
+rect[mask="url(#svg-mask-status-idle)"] {
 	fill: var(--nord13);
 }
+
+.da-status[style="background-color: rgb(250, 166, 26);"] {
+	background-color: var(--nord13) !important;
+}
+
+.da-avatar .da-wrapper[aria-label$="Invisible"] > svg > svg > rect[width="25"],
+.da-avatar[aria-label$="Invisible"] > svg > svg > rect[width="25"],
+rect[mask="url(#svg-mask-status-invisible)"] {
+	fill: var(--nord3);
+}
+
+.da-status[style="background-color: rgb(116, 127, 141);"] {
+	background-color: var(--nord3) !important;
+}
+

--- a/nord-darker.theme.css
+++ b/nord-darker.theme.css
@@ -223,7 +223,6 @@
 	fill: var(--nord15);
 }
 
-.da-pointerEvents[mask="url(#svg-mask-status-idle)"],
-.da-cursorDefault > rect  {
+.da-pointerEvents[mask="url(#svg-mask-status-idle)"] {
 	fill: var(--nord13);
 }

--- a/nord.theme.css
+++ b/nord.theme.css
@@ -166,19 +166,54 @@ foreignObject > div > div > div > svg > path {
 }
 
 /* Status icons */
-.da-pointerEvents[mask="url(#svg-mask-status-online)"], 
-.da-pointerEvents[mask="url(#svg-mask-status-online-mobile)"] {
+/* ! Better solution needed. The animation does not transit smoothly */
+.da-avatar .da-wrapper[aria-label$="Online"] > svg > svg > rect[width="25"],
+.da-avatar[aria-label$="Online"] > svg > svg > rect[width="25"],
+rect[mask="url(#svg-mask-status-online)"] {
 	fill: var(--nord14);
 }
 
-.da-pointerEvents[mask="url(#svg-mask-status-dnd)"] {
+.da-status[style="background-color: rgb(67, 181, 129);"] {
+	background-color: var(--nord14) !important;
+}
+
+
+.da-avatar .da-wrapper[aria-label$="Do Not Disturb"] > svg > svg > rect[width="25"],
+.da-avatar[aria-label$="Do Not Disturb"] > svg > svg > rect[width="25"],
+rect[mask="url(#svg-mask-status-dnd)"] {
 	fill: var(--nord11);
 }
 
-.da-pointerEvents[mask="url(#svg-mask-status-streaming)"] {
+.da-status[style="background-color: rgb(240, 71, 71);"] {
+	background-color: var(--nord11) !important;
+}
+
+.da-avatar .da-wrapper[aria-label$="Streaming"] > svg > svg > rect[width="25"],
+.da-avatar[aria-label$="Streaming"] > svg > svg > rect[width="25"],
+rect[mask="url(#svg-mask-status-streaming)"] {
 	fill: var(--nord15);
 }
 
-.da-pointerEvents[mask="url(#svg-mask-status-idle)"] {
+.da-status[style="background-color: rgb(89, 54, 149);"] {
+	background-color: var(--nord15) !important;
+}
+
+.da-avatar .da-wrapper[aria-label$="Idle"] > svg > svg > rect[width="25"],
+.da-avatar[aria-label$="Idle"] > svg > svg > rect[width="25"],
+rect[mask="url(#svg-mask-status-idle)"] {
 	fill: var(--nord13);
+}
+
+.da-status[style="background-color: rgb(250, 166, 26);"] {
+	background-color: var(--nord13) !important;
+}
+
+.da-avatar .da-wrapper[aria-label$="Invisible"] > svg > svg > rect[width="25"],
+.da-avatar[aria-label$="Invisible"] > svg > svg > rect[width="25"],
+rect[mask="url(#svg-mask-status-invisible)"] {
+	fill: var(--nord3);
+}
+
+.da-status[style="background-color: rgb(116, 127, 141);"] {
+	background-color: var(--nord3) !important;
 }

--- a/nord.theme.css
+++ b/nord.theme.css
@@ -1,14 +1,18 @@
 /**
  * @name nordDiscord
- * @description A Discord palette conversion to arcticicestudio's NordTheme. Uses mwittrien's DiscordRecolor CSS as a base with my own additions.
- * @author izutsumi, mwittrien
- * @version 1.0.0
+ * @description A Discord palette conversion to arcticicestudio's NordTheme. Uses mwittrien's DiscordRecolor CSS as a base with our own additions.
+ * @author izutsumi, IDislikeChair, mwittrien
+ * @version 1.0.1
  * @website https://github.com/izutsumi/nordDiscord
- * @source https://raw.githubusercontent.com/izutsumi/nordDiscord/master/nord.theme.css
  */
 
 /* DiscordRecolor CSS by mwittrien */
 @import url(https://mwittrien.github.io/BetterDiscordAddons/Themes/DiscordRecolor/DiscordRecolor.css);
+/* Nord Highlight.js */
+@import url("https://unpkg.com/nord-highlightjs@0.1.0/dist/nord.css");
+/* RadialStautus */
+/* @import url("https://discordstyles.github.io/RadialStatus/base.css"); */
+
 
 /* Variables from DiscordRecolor. RGBA values only. */
 :root {
@@ -29,6 +33,70 @@
 	--backgroundsecondaryalt: 	46,52,64,.4;
 	--backgroundtertiary: 		46,52,64;
 	--backgroundfloating: 		46,52,64;
+
+	/* Radial Status variable */
+	--rs-small-spacing  : 1px;            /* spacing between avatar and status */
+	--rs-large-spacing  : 3px;            /* spacing between avatar and status for user popouts & modals/profiles */
+	--rs-width          : 2px;            /* Width/thickness of status border */
+	--rs-avatar-shape   : 50%;            /* 50% for round - 0% for square */
+	--rs-online-color   : var(--nord14);  /* color for online status */
+	--rs-idle-color     : var(--nord13);  /* color for idle status */
+	--rs-dnd-color      : var(--nord11);  /* color for dnd status */
+	--rs-offline-color  : var(--nord3);   /* color for offline status */
+	--rs-streaming-color: var(--nord15);  /* color for streaming status */
+	--rs-invisible-color: var(--nord3);   /* color for invisible status - Note this will only show for your own invisibility */
+
+
+	/* Nord color scheme */
+	--nord0    : #2e3440;
+	--nord1    : #3b4252;
+	--nord2    : #434c5e;
+	--nord3    : #4c566a;
+	--nord4    : #d8dee9;
+	--nord5    : #e5e9f0;
+	--nord6    : #eceff4;
+	--nord7    : #8fbcbb;
+	--nord8    : #88c0d0;
+	--nord9    : #81a1c1;
+	--nord10   : #5e81ac;
+	--nord11   : #bf616a;
+	--nord12   : #d08770;
+	--nord13   : #ebcb8b;
+	--nord14   : #a3be8c;
+	--nord15   : #b48ead;
+	--nordBlack: #252932;
+}
+
+/* Mac style buttons */
+/* ! The clickable area is too small. */
+.da-winButton {
+	color        : transparent;
+	height       : 10px;
+	width        : 10px;
+	border-radius: 50%;
+	margin-top   : 5px;
+	margin-right : 10px;
+	margin-left  : 10px;
+
+	transition: .2s;
+}
+
+.da-winButtonMinMax[aria-label="Minimize"] {
+	background-color: var(--nord13);
+}
+
+.da-winButtonMinMax[aria-label="Maximize"] {
+	background-color: var(--nord14);
+}
+
+.da-winButtonClose {
+	background-color: var(--nord11);
+	margin-right    : 25px
+}
+
+.da-winButton:hover {
+	color           : transparent;
+	background-color: var(--nord3);
 }
 
 /* Text Highlighting Styling */
@@ -44,7 +112,7 @@
 
 /* New Messages Divider & Pill */
 .da-isUnread .da-content {
-    color: #bf616a !important;
+    color: var(--nord11) !important;
 }
 
 .da-nameWrap .da-textRow {
@@ -52,16 +120,16 @@
 }
 
 .da-isUnread {
-    border-color: #bf616a;
+    border-color: var(--nord11);
 }
 
 .da-unreadPill {
-    background-color: #bf616a;
+    background-color: var(--nord11);
 }
 
 .da-unreadPillCapStroke {
-    color: #bf616a;
-    fill: #bf616a;
+    color: var(--nord11);
+    fill: var(--nord11);
 }
 
 /* Folder Icon and Background Colors  */
@@ -70,7 +138,7 @@ foreignObject > div > div > div > svg > path {
 }
 
 .da-folderIconWrapper {
-    background-color: #4c566a !important;
+    background-color: var(--nord3) !important;
 }
 
 /* Administrator Crown */
@@ -80,9 +148,38 @@ foreignObject > div > div > div > svg > path {
 
 /* Add Server & Explore Buttons */
 .da-circleIconButton {
-    color: #8fbcbb;
+    color: var(--nord7);
 }
 
 .da-circleIconButton.da-selected, .da-selected .da-childWrapper {
-    background-color: #8fbcbb;
+    background-color: var(--nord7);
+}
+
+/* New pin icon */
+.da-iconBadge {
+	background-color: var(--nord11);
+}
+
+/* Microphone and speaker mute */
+.da-strikethrough {
+	color: var(--nord11);
+}
+
+/* Status icons */
+.da-pointerEvents[mask="url(#svg-mask-status-online)"], 
+.da-pointerEvents[mask="url(#svg-mask-status-online-mobile)"] {
+	fill: var(--nord14);
+}
+
+.da-pointerEvents[mask="url(#svg-mask-status-dnd)"] {
+	fill: var(--nord11);
+}
+
+.da-pointerEvents[mask="url(#svg-mask-status-streaming)"] {
+	fill: var(--nord15);
+}
+
+.da-pointerEvents[mask="url(#svg-mask-status-idle)"],
+.da-cursorDefault > rect  {
+	fill: var(--nord13);
 }

--- a/nord.theme.css
+++ b/nord.theme.css
@@ -179,7 +179,6 @@ foreignObject > div > div > div > svg > path {
 	fill: var(--nord15);
 }
 
-.da-pointerEvents[mask="url(#svg-mask-status-idle)"],
-.da-cursorDefault > rect  {
+.da-pointerEvents[mask="url(#svg-mask-status-idle)"] {
 	fill: var(--nord13);
 }

--- a/nord.theme.css
+++ b/nord.theme.css
@@ -169,6 +169,7 @@ foreignObject > div > div > div > svg > path {
 /* ! Better solution needed. The animation does not transit smoothly */
 .da-avatar .da-wrapper[aria-label$="Online"] > svg > svg > rect[width="25"],
 .da-avatar[aria-label$="Online"] > svg > svg > rect[width="25"],
+.da-avatar .da-wrapper[aria-label$="mobile"] > svg > rect[width="10"],
 rect[mask="url(#svg-mask-status-online)"] {
 	fill: var(--nord14);
 }


### PR DESCRIPTION
## What?
* Recolor various online status, microphone and speaker mute cross out, new pin icon, etc.
* Added dark variant theme.
* Add optional Mac style window button for Windows user, and radial status.
* Add Nord syntax highlighting.
* Rewrite some part of the original theme.
## Screenshots 
### Dark variant theme and Mac style button

![image](https://user-images.githubusercontent.com/68640628/104419396-ff3e3400-55aa-11eb-86b3-f2253cc8be5c.png)


## Anything Else?
* Issue: Mac style window buttons' clickable area are too small.